### PR TITLE
Rework fortran bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ KEEP ?= 0
 DEBUG ?= 0
 PROFAPI ?= 0
 BUILDDIR ?= build
-BUILDDIR :=$(abspath $(BUILDDIR))
+BUILDDIR := $(abspath $(BUILDDIR))
 
 CUDA_LIB ?= $(CUDA_HOME)/lib64
 CUDA_INC ?= $(CUDA_HOME)/include

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ KEEP ?= 0
 DEBUG ?= 0
 PROFAPI ?= 0
 BUILDDIR ?= build
+BUILDDIR :=$(abspath $(BUILDDIR))
 
 CUDA_LIB ?= $(CUDA_HOME)/lib64
 CUDA_INC ?= $(CUDA_HOME)/include
@@ -82,19 +83,19 @@ lib : $(INCTARGETS) $(LIBDIR)/$(LIBTARGET)
 -include $(DEPFILES)
 
 $(LIBDIR)/$(LIBTARGET) : $(LIBOBJ)
-	@printf "Linking   %-25s\n" $@
+	@printf "Linking   %-35s > %s\n" $(LIBTARGET) $@
 	mkdir -p $(LIBDIR)
 	$(CXX) $(CXXFLAGS) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBSONAME) -o $@ $(LDFLAGS) $(LIBOBJ)
 	ln -sf $(LIBSONAME) $(LIBDIR)/$(LIBNAME)
 	ln -sf $(LIBTARGET) $(LIBDIR)/$(LIBSONAME)
 
 $(INCDIR)/%.h : src/%.h
-	@printf "Grabbing  %-25s > %-25s\n" $< $@
+	@printf "Grabbing  %-35s > %s\n" $< $@
 	mkdir -p $(INCDIR)
 	cp -f $< $@
 
 $(OBJDIR)/%.o : src/%.cu
-	@printf "Compiling %-25s > %-25s\n" $< $@
+	@printf "Compiling %-35s > %s\n" $< $@
 	mkdir -p $(OBJDIR)
 	$(NVCC) -c $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" $< -o $@
 	@$(NVCC) -M $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" $< > $(@:%.o=%.d.tmp)
@@ -147,7 +148,7 @@ MPITESTBINS:= $(patsubst %, $(MPITSTDIR)/%, $(MPITESTS))
 test : $(TESTBINS)
 
 $(TSTDIR)/% : test/single/%.cu test/include/*.h $(TSTDEP)
-	@printf "Building  %-25s > %-24s\n" $< $@
+	@printf "Building  %-35s > %s\n" $< $@
 	mkdir -p $(TSTDIR)
 	$(NVCC) $(TSTINC) $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" -o $@ $< $(TSTLIB) -lcuda -lcurand -lnvToolsExt
 	@$(NVCC) -M $(TSTINC) $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" $< $(TSTLIB) -lcuda -lcurand -lnvToolsExt > $(@:%=%.d.tmp)
@@ -159,7 +160,7 @@ $(TSTDIR)/% : test/single/%.cu test/include/*.h $(TSTDEP)
 mpitest : $(MPITESTBINS)
 
 $(MPITSTDIR)/% : test/mpi/%.cu $(TSTDEP)
-	@printf "Building  %-25s > %-24s\n" $< $@
+	@printf "Building  %-35s > %s\n" $< $@
 	mkdir -p $(MPITSTDIR)
 	$(NVCC) $(MPIFLAGS) $(TSTINC) $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" -o $@ $< $(TSTLIB) -lcurand
 	@$(NVCC) $(MPIFLAGS) -M $(TSTINC) $(NVCUFLAGS) --compiler-options "$(CXXFLAGS)" $< $(TSTLIB) -lcurand > $(@:%=%.d.tmp)
@@ -193,7 +194,7 @@ debclean :
 	rm -Rf $(DEBIANDIR)
 
 $(DEBIANDIR)/% : debian/%.in
-	@printf "Generating %-25s > %-24s\n" $< $@
+	@printf "Generating %-35s > %s\n" $< $@
 	sed -e "s/\$${nccl:Major}/$(NCCL_MAJOR)/g" \
 	    -e "s/\$${nccl:Minor}/$(NCCL_MINOR)/g" \
 	    -e "s/\$${nccl:Patch}/$(NCCL_PATCH)/g" \
@@ -205,18 +206,18 @@ $(DEBIANDIR)/% : debian/%.in
 	    $< > $@
 
 $(DEBIANDIR)/% : debian/%
-	@printf "Grabbing  %-25s > %-25s\n" $< $@
+	@printf "Grabbing  %-35s > %s\n" $< $@
 	mkdir -p $(DEBIANDIR)
 	cp -f $< $@
 
 #### FORTRAN BINDINGS ####
 
-export NCCL_MAJOR NCCL_MINOR NCCL_PATCH CUDA_MAJOR CUDA_MINOR LIBLINK
+export NCCL_MAJOR NCCL_MINOR NCCL_PATCH CUDA_MAJOR CUDA_MINOR LIBLINK CUDA_LIB BUILDDIR
 
 forlib : lib
-	$(MAKE) -C fortran lib BUILDDIR=../$(BUILDDIR)
-fortest :
-	$(MAKE) -C fortran test BUILDDIR=../$(BUILDDIR)
+	$(MAKE) -C fortran lib
+fortest : forlib
+	$(MAKE) -C fortran test
 forclean :
-	$(MAKE) -C fortran clean BUILDDIR=../$(BUILDDIR)
+	$(MAKE) -C fortran clean
 

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -21,7 +21,7 @@ FCCUDAFLAGS := -Mcuda,cuda$(CUDA_MAJOR).$(CUDA_MINOR)
 FCFLAGS     := -fast -O3
 else
 # non-PGI compilers do not have CUDA support, compile our own CUDA lib
-CUDAFORDEP  := $(LIBDIR)/$(LIBCUDAFOR) 
+CUDAFORDEP  := $(LIBDIR)/$(LIBCUDAFOR)
 CUDALINK    := -L$(CUDA_LIB) -lcudart
 CUDAFORLINK := -lcudafor
 ifeq ($(FCNAME), gfortran)
@@ -39,7 +39,7 @@ ifeq ($(VERBOSE), 0)
 endif
 
 lib: $(CUDAFORDEP)
-	make $(LIBDIR)/$(LIBTARGET)
+	$(MAKE) $(LIBDIR)/$(LIBTARGET)
 
 $(LIBDIR)/$(LIBTARGET): $(OBJDIR)/ncclfor.o
 	@printf "Linking   %-35s > %s\n" $(LIBTARGET) $@
@@ -51,9 +51,9 @@ $(LIBDIR)/$(LIBTARGET): $(OBJDIR)/ncclfor.o
 $(LIBDIR)/$(LIBCUDAFOR): $(OBJDIR)/cudafor.o
 	@printf "Linking   %-35s > %s\n" $(LIBCUDAFOR) $@
 	mkdir -p $(LIBDIR)
-	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,libcudafor.so $< -o $(LIBDIR)/$(LIBCUDAFOR)
+	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBCUDAFOR) $< -o $(LIBDIR)/$(LIBCUDAFOR)
 
-$(OBJDIR)/%.o: src/%.f90 
+$(OBJDIR)/%.o: src/%.f90
 	@printf "Building  %-35s > %s\n" $< $@
 	mkdir -p $(OBJDIR)
 	mkdir -p $(INCDIR)

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -13,13 +13,14 @@ LIBLINK    += $(patsubst lib%.so,-l%,$(LIBNAME))
 
 LIBCUDAFOR := libcudafor.so
 
-ifeq ($(FCNAME), pgf90)
+ifneq ($(filter pgf%, $(FCNAME)), )
+# PGI compiler (pgfortran, pgf90, pgf95)
 FCMODFLAGS  := -module $(INCDIR)
 FCPREFLAGS  := -Mpreprocess
 FCCUDAFLAGS := -Mcuda,cuda$(CUDA_MAJOR).$(CUDA_MINOR)
 FCFLAGS     := -fast -O3
 else
-# non-pgf90 do not have CUDA support, compile our own CUDA lib
+# non-PGI compilers do not have CUDA support, compile our own CUDA lib
 CUDAFORDEP  := $(LIBDIR)/$(LIBCUDAFOR) 
 CUDALINK    := -L$(CUDA_LIB) -lcudart
 CUDAFORLINK := -lcudafor
@@ -27,7 +28,7 @@ ifeq ($(FCNAME), gfortran)
 FCMODFLAGS  := -J$(INCDIR)
 FCPREFLAGS  += -cpp
 FCFLAGS     += -ffree-line-length-none
-else ifeq ($(FC), ifort)
+else ifeq ($(FCNAME), ifort)
 FCMODFLAGS  := -module $(INCDIR)
 FCPREFLAGS  += -fpp
 endif
@@ -41,21 +42,25 @@ lib: $(CUDAFORDEP)
 	make $(LIBDIR)/$(LIBTARGET)
 
 $(LIBDIR)/$(LIBTARGET): $(OBJDIR)/ncclfor.o
-	@printf "Linking   %-25s\n" $@
+	@printf "Linking   %-35s > %s\n" $(LIBTARGET) $@
+	mkdir -p $(LIBDIR)
 	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBSONAME) $< -o $(LIBDIR)/$(LIBTARGET)
 	ln -sf $(LIBSONAME) $(LIBDIR)/$(LIBNAME)
 	ln -sf $(LIBTARGET) $(LIBDIR)/$(LIBSONAME)
 
 $(LIBDIR)/$(LIBCUDAFOR): $(OBJDIR)/cudafor.o
-	@printf "Linking   %-25s\n" $@
+	@printf "Linking   %-35s > %s\n" $(LIBCUDAFOR) $@
+	mkdir -p $(LIBDIR)
 	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,libcudafor.so $< -o $(LIBDIR)/$(LIBCUDAFOR)
 
 $(OBJDIR)/%.o: src/%.f90 
-	@printf "Building  %-25s > %-24s\n" $< $@
+	@printf "Building  %-35s > %s\n" $< $@
+	mkdir -p $(OBJDIR)
+	mkdir -p $(INCDIR)
 	$(FC) -c $(FCMODFLAGS) $(FCPREFLAGS) -fPIC $(FCCUDAFLAGS) $(FCFLAGS) $< -o $@
 
 TESTS := reduce_ptr_out allreduce_ptr_out reducescatter_ptr_out broadcast_ptr allgather_ptr_out
-ifeq ($(FCNAME), pgf90)
+ifneq ($(filter pgf%, $(FCNAME)), )
 TESTS += reduce_arr_out allreduce_arr_out reducescatter_arr_out broadcast_arr allgather_arr_out
 endif
 
@@ -65,11 +70,12 @@ TESTBINS := $(patsubst %,$(TESTDIR)/%,$(TESTS))
 test: lib $(TESTBINS)
 
 $(TESTDIR)/%: test/%.f90 lib
-	@printf "Building  %-25s > %-24s\n" $< $@
+	@printf "Building  %-35s > %s\n" $< $@
 	@mkdir -p $(TESTDIR)
 	$(FC) $(FCCUDAFLAGS) $(FCFLAGS) $< $(CUDALINK) -I$(INCDIR) -L$(LIBDIR) $(CUDAFORLINK) $(LIBLINK) -o $@
 
 clean:
-	rm -f $(LIBDIR)/$(LIBTARGET) $(LIBDIR)/$(LIBCUDAFOR) $(OBJDIR)/*for.o $(INCDIR)/*.mod
+	rm -f $(LIBDIR)/$(LIBTARGET) $(LIBDIR)/$(LIBSONAME) $(LIBDIR)/$(LIBNAME)
+	rm -f $(LIBDIR)/$(LIBCUDAFOR) $(OBJDIR)/*for.o $(INCDIR)/*.mod
 	rm -rf $(TESTDIR)/
 

--- a/fortran/Makefile
+++ b/fortran/Makefile
@@ -1,52 +1,62 @@
 FC := gfortran
+FCNAME := $(notdir $(FC))
 
-LIBNAME   := libncclfor.so
-LIBSONAME := $(patsubst %,%.$(NCCL_MAJOR),$(LIBNAME))
-LIBTARGET := $(patsubst %,%.$(NCCL_MAJOR).$(NCCL_MINOR).$(NCCL_PATCH),$(LIBNAME))
-LIBLINK   += $(patsubst lib%.so,-l%,$(LIBNAME))
+BUILDDIR ?= ../build
+INCDIR := $(BUILDDIR)/include
+LIBDIR := $(BUILDDIR)/lib
+OBJDIR := $(BUILDDIR)/obj
 
-ifeq ($(FC), gfortran)
-FCMODFLAGS  := -J$(INCDIR)
-FCPREFLAGS  := -cpp
-FCCUDAFLAGS :=
-FCFLAGS     := -ffree-line-length-none
-CUDAFORDEP  := libcudafor
-CUDALINK    := -L$(CUDA_LIB) -lcudart
-CUDAFORLINK := -lcudafor
-else ifeq ($(FC), ifort)
-FCMODFLAGS  := -module $(INCDIR)
-FCPREFLAGS  := -fpp
-FCCUDAFLAGS :=
-FCFLAGS     :=
-CUDAFORDEP  := libcudafor
-CUDALINK    := -L$(CUDA_LIB) -lcudart
-CUDAFORLINK := -lcudafor
-else
+LIBNAME    := libncclfor.so
+LIBSONAME  := $(patsubst %,%.$(NCCL_MAJOR),$(LIBNAME))
+LIBTARGET  := $(patsubst %,%.$(NCCL_MAJOR).$(NCCL_MINOR).$(NCCL_PATCH),$(LIBNAME))
+LIBLINK    += $(patsubst lib%.so,-l%,$(LIBNAME))
+
+LIBCUDAFOR := libcudafor.so
+
+ifeq ($(FCNAME), pgf90)
 FCMODFLAGS  := -module $(INCDIR)
 FCPREFLAGS  := -Mpreprocess
 FCCUDAFLAGS := -Mcuda,cuda$(CUDA_MAJOR).$(CUDA_MINOR)
 FCFLAGS     := -fast -O3
-CUDAFORDEP  :=
-CUDALINK    :=
-CUDAFORLINK :=
+else
+# non-pgf90 do not have CUDA support, compile our own CUDA lib
+CUDAFORDEP  := $(LIBDIR)/$(LIBCUDAFOR) 
+CUDALINK    := -L$(CUDA_LIB) -lcudart
+CUDAFORLINK := -lcudafor
+ifeq ($(FCNAME), gfortran)
+FCMODFLAGS  := -J$(INCDIR)
+FCPREFLAGS  += -cpp
+FCFLAGS     += -ffree-line-length-none
+else ifeq ($(FC), ifort)
+FCMODFLAGS  := -module $(INCDIR)
+FCPREFLAGS  += -fpp
+endif
+endif
+
+ifeq ($(VERBOSE), 0)
+.SILENT:
 endif
 
 lib: $(CUDAFORDEP)
-	$(FC) -c $(FCMODFLAGS) $(FCPREFLAGS) -fPIC $(FCCUDAFLAGS) $(FCFLAGS) src/ncclfor.f90 -o $(OBJDIR)/ncclfor.o
-	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBSONAME) $(OBJDIR)/ncclfor.o -o $(LIBDIR)/$(LIBTARGET)
+	make $(LIBDIR)/$(LIBTARGET)
+
+$(LIBDIR)/$(LIBTARGET): $(OBJDIR)/ncclfor.o
+	@printf "Linking   %-25s\n" $@
+	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,$(LIBSONAME) $< -o $(LIBDIR)/$(LIBTARGET)
 	ln -sf $(LIBSONAME) $(LIBDIR)/$(LIBNAME)
 	ln -sf $(LIBTARGET) $(LIBDIR)/$(LIBSONAME)
 
-export
+$(LIBDIR)/$(LIBCUDAFOR): $(OBJDIR)/cudafor.o
+	@printf "Linking   %-25s\n" $@
+	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,libcudafor.so $< -o $(LIBDIR)/$(LIBCUDAFOR)
 
-libcudafor:
-	$(MAKE) -C cudafor lib
+$(OBJDIR)/%.o: src/%.f90 
+	@printf "Building  %-25s > %-24s\n" $< $@
+	$(FC) -c $(FCMODFLAGS) $(FCPREFLAGS) -fPIC $(FCCUDAFLAGS) $(FCFLAGS) $< -o $@
 
 TESTS := reduce_ptr_out allreduce_ptr_out reducescatter_ptr_out broadcast_ptr allgather_ptr_out
-ifneq ($(FC), gfortran)
-ifneq ($(FC), ifort)
+ifeq ($(FCNAME), pgf90)
 TESTS += reduce_arr_out allreduce_arr_out reducescatter_arr_out broadcast_arr allgather_arr_out
-endif
 endif
 
 TESTDIR  := $(BUILDDIR)/test/fortran
@@ -54,13 +64,12 @@ TESTBINS := $(patsubst %,$(TESTDIR)/%,$(TESTS))
 
 test: lib $(TESTBINS)
 
-$(TESTDIR)/%: test/%.f90
+$(TESTDIR)/%: test/%.f90 lib
+	@printf "Building  %-25s > %-24s\n" $< $@
 	@mkdir -p $(TESTDIR)
 	$(FC) $(FCCUDAFLAGS) $(FCFLAGS) $< $(CUDALINK) -I$(INCDIR) -L$(LIBDIR) $(CUDAFORLINK) $(LIBLINK) -o $@
 
 clean:
-	rm -rf $(INCDIR)/*.mod
-	rm -rf $(LIBDIR)/lib*for.so*
-	rm -rf $(OBJDIR)/*for.o
+	rm -f $(LIBDIR)/$(LIBTARGET) $(LIBDIR)/$(LIBCUDAFOR) $(OBJDIR)/*for.o $(INCDIR)/*.mod
 	rm -rf $(TESTDIR)/
 

--- a/fortran/cudafor/Makefile
+++ b/fortran/cudafor/Makefile
@@ -1,4 +1,0 @@
-lib:
-	$(FC) -c $(FCMODFLAGS) $(FCPREFLAGS) -fPIC $(FCCUDAFLAGS) $(FCFLAGS) src/cudafor.f90 -o $(OBJDIR)/cudafor.o
-	$(FC) -shared -Wl,--no-as-needed -Wl,-soname,libcudafor.so $(OBJDIR)/cudafor.o -o $(LIBDIR)/libcudafor.so
-

--- a/fortran/src/cudafor.f90
+++ b/fortran/src/cudafor.f90
@@ -82,17 +82,33 @@ end function cudaMalloc
 end interface cudaMalloc
 !End cudaMalloc
 
-!Start cudaMemcpy
-interface cudaMemcpy
-integer(c_int) function cudaMemcpy(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+!Start cudaMemCpy
+interface cudaMemCpy
+
+!Start cudaMemCpyH2D
+integer(c_int) function cudaMemCpyH2D(dst, src, count, kind) bind(c, name = "cudaMemcpy")
 import :: c_ptr, c_int, c_size_t
-import :: c_devptr, cudaMemcpyKind
+import :: c_devptr, cudaMemCpyKind
 implicit none
 type(c_devptr), value :: dst
 type(c_ptr), value :: src
 integer(c_size_t), value :: count
-type(cudaMemcpyKind), value :: kind
-end function cudaMemcpy
+type(cudaMemCpyKind), value :: kind
+end function cudaMemCpyH2D
+!End cudaMemCpyH2D
+
+!Start cudaMemCpyD2H
+integer(c_int) function cudaMemCpyD2H(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+import :: c_ptr, c_int, c_size_t
+import :: c_devptr, cudaMemCpyKind
+implicit none
+type(c_ptr), value :: dst
+type(c_devptr), value :: src
+integer(c_size_t), value :: count
+type(cudaMemCpyKind), value :: kind
+end function cudaMemCpyD2H
+!End cudaMemCpyD2H
+
 end interface cudaMemcpy
 !End cudaMemcpy
 

--- a/fortran/src/cudafor.f90
+++ b/fortran/src/cudafor.f90
@@ -6,17 +6,17 @@ use iso_c_binding
 implicit none
 private
 public :: c_devptr
-public :: cudaMemCpyKind,           &
-          cudaMemCpyHostToHost,     &
-          cudaMemCpyHostToDevice,   &
-          cudaMemCpyDeviceToHost,   &
-          cudaMemCpyDeviceToDevice, &
-          cudaMemCpyDefault
+public :: cudaMemcpyKind,           &
+          cudaMemcpyHostToHost,     &
+          cudaMemcpyHostToDevice,   &
+          cudaMemcpyDeviceToHost,   &
+          cudaMemcpyDeviceToDevice, &
+          cudaMemcpyDefault
 public :: cuda_stream_kind
 public :: cudaGetDeviceCount
 public :: cudaSetDevice
 public :: cudaMalloc
-public :: cudaMemCpy
+public :: cudaMemcpy
 public :: cudaFree
 public :: cudaStreamCreate
 public :: cudaStreamSynchronize
@@ -30,17 +30,17 @@ type(c_ptr) :: member
 end type c_devptr
 !End c_devptr
 
-!Start cudaMemCpyKind
-type, bind(c) :: cudaMemCpyKind
+!Start cudaMemcpyKind
+type, bind(c) :: cudaMemcpyKind
 integer(c_int) :: member
-end type cudaMemCpyKind
+end type cudaMemcpyKind
 
-type(cudaMemCpyKind), parameter :: cudaMemCpyHostToHost     = cudaMemCpyKind(0), &
-                                   cudaMemCpyHostToDevice   = cudaMemCpyKind(1), &
-                                   cudaMemCpyDeviceToHost   = cudaMemCpyKind(2), &
-                                   cudaMemCpyDeviceToDevice = cudaMemCpyKind(3), &
-                                   cudaMemCpyDefault        = cudaMemCpyKind(4)
-!End cudaMemCpyKind
+type(cudaMemcpyKind), parameter :: cudaMemcpyHostToHost     = cudaMemcpyKind(0), &
+                                   cudaMemcpyHostToDevice   = cudaMemcpyKind(1), &
+                                   cudaMemcpyDeviceToHost   = cudaMemcpyKind(2), &
+                                   cudaMemcpyDeviceToDevice = cudaMemcpyKind(3), &
+                                   cudaMemcpyDefault        = cudaMemcpyKind(4)
+!End cudaMemcpyKind
 
 !Start cuda_stream_kind
 integer(c_intptr_t), parameter :: cuda_stream_kind = c_intptr_t
@@ -82,19 +82,19 @@ end function cudaMalloc
 end interface cudaMalloc
 !End cudaMalloc
 
-!Start cudaMemCpy
-interface cudaMemCpy
-integer(c_int) function cudaMemCpy(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+!Start cudaMemcpy
+interface cudaMemcpy
+integer(c_int) function cudaMemcpy(dst, src, count, kind) bind(c, name = "cudaMemcpy")
 import :: c_ptr, c_int, c_size_t
-import :: c_devptr, cudaMemCpyKind
+import :: c_devptr, cudaMemcpyKind
 implicit none
 type(c_devptr), value :: dst
 type(c_ptr), value :: src
 integer(c_size_t), value :: count
-type(cudaMemCpyKind), value :: kind
-end function cudaMemCpy
-end interface cudaMemCpy
-!End cudaMemCpy
+type(cudaMemcpyKind), value :: kind
+end function cudaMemcpy
+end interface cudaMemcpy
+!End cudaMemcpy
 
 !Start cudaFree
 interface cudaFree

--- a/fortran/src/cudafor.f90
+++ b/fortran/src/cudafor.f90
@@ -15,7 +15,7 @@ public :: cudaMemCpyKind,           &
 public :: cuda_stream_kind
 public :: cudaGetDeviceCount
 public :: cudaSetDevice
-public :: cudaMAlloc
+public :: cudaMalloc
 public :: cudaMemCpy
 public :: cudaFree
 public :: cudaStreamCreate
@@ -70,23 +70,21 @@ end function cudaSetDevice
 end interface cudaSetDevice
 !End cudaSetDevice
 
-!Start cudaMAlloc
-interface cudaMAlloc
-integer(c_int) function cudaMAlloc(devPtr, size) bind(c, name = "cudaMalloc")
+!Start cudaMalloc
+interface cudaMalloc
+integer(c_int) function cudaMalloc(devPtr, size) bind(c, name = "cudaMalloc")
 import :: c_int, c_size_t
 import :: c_devptr
 implicit none
 type(c_devptr) :: devPtr
 integer(c_size_t), value :: size
-end function cudaMAlloc
-end interface cudaMAlloc
-!End cudaMAlloc
+end function cudaMalloc
+end interface cudaMalloc
+!End cudaMalloc
 
 !Start cudaMemCpy
 interface cudaMemCpy
-
-!Start cudaMemCpyH2D
-integer(c_int) function cudaMemCpyH2D(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+integer(c_int) function cudaMemCpy(dst, src, count, kind) bind(c, name = "cudaMemcpy")
 import :: c_ptr, c_int, c_size_t
 import :: c_devptr, cudaMemCpyKind
 implicit none
@@ -94,21 +92,7 @@ type(c_devptr), value :: dst
 type(c_ptr), value :: src
 integer(c_size_t), value :: count
 type(cudaMemCpyKind), value :: kind
-end function cudaMemCpyH2D
-!End cudaMemCpyH2D
-
-!Start cudaMemCpyD2H
-integer(c_int) function cudaMemCpyD2H(dst, src, count, kind) bind(c, name = "cudaMemcpy")
-import :: c_ptr, c_int, c_size_t
-import :: c_devptr, cudaMemCpyKind
-implicit none
-type(c_ptr), value :: dst
-type(c_devptr), value :: src
-integer(c_size_t), value :: count
-type(cudaMemCpyKind), value :: kind
-end function cudaMemCpyD2H
-!End cudaMemCpyD2H
-
+end function cudaMemCpy
 end interface cudaMemCpy
 !End cudaMemCpy
 

--- a/fortran/src/cudafor.f90
+++ b/fortran/src/cudafor.f90
@@ -82,32 +82,32 @@ end function cudaMalloc
 end interface cudaMalloc
 !End cudaMalloc
 
-!Start cudaMemCpy
-interface cudaMemCpy
+!Start cudaMemcpy
+interface cudaMemcpy
 
-!Start cudaMemCpyH2D
-integer(c_int) function cudaMemCpyH2D(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+!Start cudaMemcpyH2D
+integer(c_int) function cudaMemcpyH2D(dst, src, count, kind) bind(c, name = "cudaMemcpy")
 import :: c_ptr, c_int, c_size_t
-import :: c_devptr, cudaMemCpyKind
+import :: c_devptr, cudaMemcpyKind
 implicit none
 type(c_devptr), value :: dst
 type(c_ptr), value :: src
 integer(c_size_t), value :: count
-type(cudaMemCpyKind), value :: kind
-end function cudaMemCpyH2D
-!End cudaMemCpyH2D
+type(cudaMemcpyKind), value :: kind
+end function cudaMemcpyH2D
+!End cudaMemcpyH2D
 
-!Start cudaMemCpyD2H
-integer(c_int) function cudaMemCpyD2H(dst, src, count, kind) bind(c, name = "cudaMemcpy")
+!Start cudaMemcpyD2H
+integer(c_int) function cudaMemcpyD2H(dst, src, count, kind) bind(c, name = "cudaMemcpy")
 import :: c_ptr, c_int, c_size_t
-import :: c_devptr, cudaMemCpyKind
+import :: c_devptr, cudaMemcpyKind
 implicit none
 type(c_ptr), value :: dst
 type(c_devptr), value :: src
 integer(c_size_t), value :: count
-type(cudaMemCpyKind), value :: kind
-end function cudaMemCpyD2H
-!End cudaMemCpyD2H
+type(cudaMemcpyKind), value :: kind
+end function cudaMemcpyD2H
+!End cudaMemcpyD2H
 
 end interface cudaMemcpy
 !End cudaMemcpy

--- a/fortran/src/ncclfor.f90
+++ b/fortran/src/ncclfor.f90
@@ -54,7 +54,7 @@ public :: ncclCommDestroy
 public :: ncclReduce
 public :: ncclAllReduce
 public :: ncclReduceScatter
-public :: ncclBCast
+public :: ncclBcast
 public :: ncclAllGather
 
 !Start types
@@ -265,9 +265,9 @@ end function ncclReduceScatter
 end interface ncclReduceScatter
 !End ncclReduceScatter
 
-!Start ncclBCast
-interface ncclBCast
-type(ncclResult) function ncclBCast(buff, count, datatype, root, comm, stream) bind(c, name = 'ncclBcast')
+!Start ncclBcast
+interface ncclBcast
+type(ncclResult) function ncclBcast(buff, count, datatype, root, comm, stream) bind(c, name = 'ncclBcast')
 import :: c_int
 import :: c_devptr, cuda_stream_kind
 import :: ncclResult, ncclComm, ncclDataType
@@ -278,9 +278,9 @@ type(ncclDataType), value :: datatype
 integer(c_int), value :: root
 type(ncclComm), value :: comm
 integer(cuda_stream_kind), value :: stream
-end function ncclBCast
-end interface ncclBCast
-!End ncclBCast
+end function ncclBcast
+end interface ncclBcast
+!End ncclBcast
 
 !Start ncclAllGather
 interface ncclAllGather

--- a/fortran/test/allgather_ptr_out.f90
+++ b/fortran/test/allgather_ptr_out.f90
@@ -76,7 +76,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
@@ -88,7 +88,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
-    stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
@@ -103,7 +103,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(i), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(i), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyDeviceToHost)
   end do
 
   print "(a)", ""
@@ -119,7 +119,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(i), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(i), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
   end do
 
   err = maxval(abs(hostBuff(:, 1) / hostBuff(:, nDev + 1) - 1.0_real32))

--- a/fortran/test/allgather_ptr_out.f90
+++ b/fortran/test/allgather_ptr_out.f90
@@ -75,7 +75,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 
@@ -87,7 +87,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
     stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemCpyHostToDevice)
   end do
 

--- a/fortran/test/allreduce_ptr_out.f90
+++ b/fortran/test/allreduce_ptr_out.f90
@@ -82,7 +82,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 
@@ -90,7 +90,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 

--- a/fortran/test/allreduce_ptr_out.f90
+++ b/fortran/test/allreduce_ptr_out.f90
@@ -83,7 +83,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   allocate(recvBuffPtr(nDev))
@@ -91,7 +91,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
@@ -108,7 +108,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   print "(a)", "after allreduce:"
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
     err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, nDev + 2) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
   end do
@@ -116,7 +116,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   print "(a)", ""
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(nDev + 1), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(nDev + 1), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
     err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
   end do

--- a/fortran/test/broadcast_arr.f90
+++ b/fortran/test/broadcast_arr.f90
@@ -79,7 +79,7 @@ type(c_devptr), allocatable :: devBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    res = ncclBCast(devBuffPtr(i), nEl, dataType, root, comm(i), stream(i))
+    res = ncclBcast(devBuffPtr(i), nEl, dataType, root, comm(i), stream(i))
   end do
 
   do i = 1, nDev

--- a/fortran/test/broadcast_ptr.f90
+++ b/fortran/test/broadcast_ptr.f90
@@ -79,12 +79,12 @@ type(c_devptr), allocatable :: devBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(devBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(devBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    res = ncclBCast(devBuffPtr(i), nEl, dataType, root, comm(i), stream(i))
+    res = ncclBcast(devBuffPtr(i), nEl, dataType, root, comm(i), stream(i))
   end do
 
   do i = 1, nDev
@@ -94,7 +94,7 @@ type(c_devptr), allocatable :: devBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(i), devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(i), devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
   end do
 
   print "(a)", ""

--- a/fortran/test/broadcast_ptr.f90
+++ b/fortran/test/broadcast_ptr.f90
@@ -78,7 +78,7 @@ type(c_devptr), allocatable :: devBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(devBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(devBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 

--- a/fortran/test/reduce_ptr_out.f90
+++ b/fortran/test/reduce_ptr_out.f90
@@ -82,7 +82,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 
@@ -90,7 +90,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 

--- a/fortran/test/reduce_ptr_out.f90
+++ b/fortran/test/reduce_ptr_out.f90
@@ -83,7 +83,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   allocate(recvBuffPtr(nDev))
@@ -91,7 +91,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
@@ -105,7 +105,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   end do
 
   stat = cudaSetDevice(devList(root + 1))
-  stat = cudaMemCpy(hostBuffPtr(nDev + 1), recvBuffPtr(root + 1), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+  stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(root + 1), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
 
   print "(a)", ""
   print "(a)", "after reduce:"
@@ -115,7 +115,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   print "(a)", ""
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(nDev + 1), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(nDev + 1), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
     err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
   end do
@@ -124,7 +124,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     if (i - 1 /= root) then
       stat = cudaSetDevice(devList(i))
-      stat = cudaMemCpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+      stat = cudaMemcpy(hostBuffPtr(nDev + 1), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
       err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
       print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff of rank ", i - 1," = ", err
     end if

--- a/fortran/test/reducescatter_ptr_out.f90
+++ b/fortran/test/reducescatter_ptr_out.f90
@@ -83,7 +83,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
-    stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
@@ -95,7 +95,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
     stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
-    stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
+    stat = cudaMemcpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyHostToDevice)
   end do
 
   do i = 1, nDev
@@ -112,7 +112,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   print "(a)", "after reduceScatter:"
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(i), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(i), recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemcpyDeviceToHost)
     err = maxval(abs(hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 1) / hostBuff((i - 1) * nEl + 1:i * nEl, nDev + 2) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in recvbuff from rank ", i - 1," = ", err
   end do
@@ -124,7 +124,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
   print "(a)", ""
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMemCpy(hostBuffPtr(i), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemCpyDeviceToHost)
+    stat = cudaMemcpy(hostBuffPtr(i), sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemcpyDeviceToHost)
     err = maxval(abs(hostBuff(:, nDev + 1) / hostBuff(:, i) - 1.0_real32))
     print "(a, i2.2, a, e11.4e2)", "maximum error in sendbuff of rank ", i - 1," = ", err
   end do

--- a/fortran/test/reducescatter_ptr_out.f90
+++ b/fortran/test/reducescatter_ptr_out.f90
@@ -82,7 +82,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
+    stat = cudaMalloc(sendBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev)
     stat = cudaMemCpy(sendBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)) * nDev, cudaMemCpyHostToDevice)
   end do
 
@@ -94,7 +94,7 @@ type(c_devptr), allocatable :: recvBuffPtr(:)
 
   do i = 1, nDev
     stat = cudaSetDevice(devList(i))
-    stat = cudaMAlloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
+    stat = cudaMalloc(recvBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)))
     stat = cudaMemCpy(recvBuffPtr(i), hostBuffPtr(i), nEl * c_sizeof(hostBuff(1, 1)), cudaMemCpyHostToDevice)
   end do
 


### PR DESCRIPTION
Hi Kyle,

I spent some time on the fortran bindings. It works fine with pgf90, with gfortran the lib compiles but not the tests (complains about size_of, I guess I would need a more recent gfortran). I didn't test with ifort. Please find the changelog below and let me know if you think something is a bad idea or is wrong.

Sylvain

========
Change cudaMAlloc to cudaMalloc
Replace cudaMemcpyH2D and cudaMemcpyD2H by cudaMemcpy
Move fortran/cudafor/src/cudafor.f90 to fortran/src/cudafor.f90 to simplify and remove an extra subdir + Makefile
Check compiler name with notdir so that you can specify the compiler with an absolute path
Explicitely export env variables between the main Makefile and the Fortran Makefile
Move fortran targets at the end of the main Makefile
Fix multiple dependencies in the fortran Makefile so that make -j works
Add .SILENT and printfs in the fortran Makefile to have a pretty output like the rest